### PR TITLE
修复 mknanduboot.sh 中 od 版本判断时 逻辑错误

### DIFF
--- a/board/allwinner/generic/scripts/mknanduboot.sh
+++ b/board/allwinner/generic/scripts/mknanduboot.sh
@@ -14,8 +14,8 @@ set -e
 OUTPUT="$2"
 UBOOT="$1"
 
-TOOLCHECK=$(od --help | grep 'endia')
-if [ "$TOOLCHECK" == "" ]; then
+TOOLCHECK=$(od --help | grep 'endia'; echo $?)
+if [ "$TOOLCHECK" == "1" ]; then
 	echo "od cmd is too old not support endia"
 	exit -1
 fi

--- a/board/widora/mangopi/r3/devicetree/linux/devicetree.dts
+++ b/board/widora/mangopi/r3/devicetree/linux/devicetree.dts
@@ -13,7 +13,8 @@
 		#size-cells = <1>;
 		ranges;
 
-		bootargs = "console=ttyS0,115200 rootwait init=/preinit root=/dev/mtdblock2 rootfstype=squashfs overlayfsdev=/dev/mtdblock3";
+		//bootargs = "console=ttyS0,115200 rootwait init=/preinit root=/dev/mtdblock2 rootfstype=squashfs overlayfsdev=/dev/mtdblock3";
+		bootargs = "console=ttyS0,115200 rootwait init=/preinit root=/dev/mmcblk0p3 rootfstype=ext4 ";
 
 		simplefb_lcd: framebuffer-lcd0 {
 			compatible = "allwinner,simple-framebuffer",


### PR DESCRIPTION
默认 od 版本为 5.1，$(od --help | grep 'endia') 执行时会返回 0，从而直接退出该脚本，导致后续的判断及错误提示信息无作用。
更改为判断 grep 返回值方式即可。